### PR TITLE
Link to searx instances

### DIFF
--- a/index.html
+++ b/index.html
@@ -1376,7 +1376,7 @@
 								<button type="button" class="btn btn-success">Website: searx.me</button>
 							</a>
 							<a href="https://github.com/asciimoo/searx/wiki/Searx-instances">
-								<button type="button" class="btn btn-success">Instances: github.com</button>
+								<button type="button" class="btn btn-success">List of Instances</button>
 							</a>
 						</p>
             </div>

--- a/index.html
+++ b/index.html
@@ -1371,7 +1371,14 @@
             <div class="panel-body">
               <p><img src="img/provider/searx.jpg" alt="searx" align="right" style="margin-left:5px;">An <a href="https://github.com/asciimoo/searx">open source</a> metasearch engine, aggregating the results of other search engines while not storing information about its users. No logs, no ads and no tracking.</p>
 
-              <p><a href="https://searx.me/"><button type="button" class="btn btn-success">Website: searx.me</button></a></p>
+						<p>
+							<a href="https://searx.me/">
+								<button type="button" class="btn btn-success">Website: searx.me</button>
+							</a>
+							<a href="https://github.com/asciimoo/searx/wiki/Searx-instances">
+								<button type="button" class="btn btn-success">Instances: github.com</button>
+							</a>
+						</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
https://github.com/privacytoolsIO/privacytools.io/pull/89

> I think a link to other instances is advisable. That's one of the ideas behind searx and most users looking for searx will probably not see that there's more than one instance. Searx.me isn't neccessarily the best instance for everyone either (it doesn't proxy images by default for example). On the other hand linking to only github.io or github.com will keep the user from immediatly being able to try searx out and might scare them off. I therefore added a second button linking to the list of instances.