### PR TITLE
Fix VPN provider table sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@
 								<td data-value="AzireVPN">
 									<a href="https://www.azirevpn.com/"><img src="img/provider/AzireVPN.gif" width="200" height="70"></a>
 								</td>
-								<td data-value="45">45 €</td>
+								<td data-value="47.5">45 €</td> <!-- Nord costs $48, 47.5 rounded is 48 => didn't round this one -->
 								<td><span class="label label-warning">No</span></td>
 								<td>5</td>
 								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>
@@ -354,7 +354,7 @@
 								<td data-value="blackVPN">
 									<a href="https://www.blackvpn.com/"><img src="img/provider/blackVPN.gif" width="200" height="70"></a>
 								</td>
-								<td data-value="99">99 €</td>
+								<td data-value="105">99 €</td>
 								<td><span class="label label-warning">No</span></td>
 								<td>27</td>
 								<td><span class="flag-icon flag-icon-hk"></span> Hong Kong</td>
@@ -387,7 +387,7 @@
 								<td data-value="EarthVPN">
 									<a href="http://www.earthvpn.com/"><img src="img/provider/EarthVPN.gif" width="200" height="70"></a>
 								</td>
-								<td data-value="40">39,99 €</td>
+								<td data-value="42">39,99 €</td>
 								<td><span class="label label-warning">No</span></td>
 								<td>432</td>
 								<td><span class="flag-icon flag-icon-cy"></span> Northern Cyprus</td>
@@ -431,7 +431,7 @@
 								<td data-value="Mullvad">
 									<a href="https://mullvad.net/"><img src="img/provider/Mullvad.gif" width="200" height="70"></a>
 								</td>
-								<td data-value="60">60 €</td>
+								<td data-value="63">60 €</td>
 								<td><span class="label label-success">Yes</span></td>
 								<td>23</td>
 								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>
@@ -453,7 +453,7 @@
 								<td data-value="oVPN.se">
 									<a href="https://www.ovpn.se/"><img src="img/provider/oVPN.se.gif" width="200" height="70"></a>
 								</td>
-								<td data-value="84">84 €</td>
+								<td data-value="89">84 €</td>
 								<td><span class="label label-success">Yes</span></td>
 								<td>24</td>
 								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>
@@ -464,7 +464,7 @@
 								<td data-value="Perfect Privacy">
 									<a href="https://www.perfect-privacy.com/"><img src="img/provider/Perfect-Privacy.gif" width="200" height="70"></a>
 								</td>
-								<td data-value="150">150 €</td>
+								<td data-value="159">150 €</td>
 								<td><span class="label label-warning">No</span></td>
 								<td>41</td>
 								<td><span class="flag-icon flag-icon-pa"></span> Panama</td>
@@ -522,7 +522,7 @@
 								<td data-value="VPNTunnel">
 									<a href="https://vpntunnel.com/"><img src="img/provider/VPNTunnel.gif" width="200" height="70"></a>
 								</td>
-								<td data-value="35.88">35,88 €</td>
+								<td data-value="38">35,88 €</td>
 								<td><span class="label label-warning">No</span></td>
 								<td>80</td>
 								<td><span class="flag-icon flag-icon-se"></span> Sweden</td>


### PR DESCRIPTION
https://github.com/privacytoolsIO/privacytools.io/pull/112

> All values (apart from AzireVPN which is not rounded to a whole number to not interfere with NordVPN's $48 / year) rounded, in dollars.